### PR TITLE
Fixes workshop uploading(partially)

### DIFF
--- a/src/pysteamcmd/steamcmd.py
+++ b/src/pysteamcmd/steamcmd.py
@@ -169,7 +169,7 @@ class Steamcmd(object):
             vdf_data = self._parse_vdf_text(vdf_data=workshop_vdf)
 
         with open("{install_path}/workshop.vdf".format(install_path=self.install_path), "w") as vdf_file:
-            vdf.dumps(vdf_data, vdf_file)
+            vdf.dump(vdf_data, vdf_file)
 
         # Upload the workshop files
         steamcmd_params = (


### PR DESCRIPTION
vdf.dumps dumps to a string. I believe the intended function is `dump` which dumps to a file

only partially because parse_vdf_text isnt setup